### PR TITLE
Fix: Tiny icons on Android tablets

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -48,6 +48,13 @@
     transition: transform 0.1s ease-in-out, background-color 0.15s;
 }
 
+.reading-highlighter-btn svg,
+.reading-highlighter-btn .svg-icon {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+}
+
 /* Light Mode Consistency */
 .theme-light .reading-highlighter-btn {
     /* Match the Erase Button look EXACTLY: rgba(200, 200, 200, 0.95) */


### PR DESCRIPTION
**Problem:** The SVG icons inside the floating toolbar buttons appeared extremely small on Android tablets, making them unidentifiable. The button circles themselves rendered at the correct size. On Windows, Mac, and iOS, icons appeared normal.

**Root cause:** The floating toolbar container is appended to `document.body` (outside Obsidian's main DOM hierarchy), so it doesn't inherit Obsidian's CSS variable `--icon-size`. On most platforms, the SVG defaults happen to look correct, but on Android tablets the SVGs fall back to their intrinsic minimum size. The plugin's CSS never defined an explicit size for the SVG icons inside the buttons.

**Solution:** Added an explicit CSS rule for SVG icons inside toolbar buttons.

**Changes in `styles.css`:**

- **Added** the following rule after `.reading-highlighter-btn`:

```css
.reading-highlighter-btn svg,
.reading-highlighter-btn .svg-icon {
    width: 18px;
    height: 18px;
    flex-shrink: 0;
}
```

This forces a consistent 18px icon size on all platforms. On Windows/Mac/iOS where icons already rendered at ~18px by inheritance, there is no visual difference. On Android, it fixes the tiny icon issue.