### PR TITLE
Fix: Auto-highlight on Android (erratic behavior) AND Feature: Tap on…

### DIFF
--- a/main.js
+++ b/main.js
@@ -144,9 +144,6 @@ var FloatingManager = class {
   load() {
     this.createElements();
     this.registerEvents();
-    if (import_obsidian.Platform.isMobile) {
-      this.setupMobileGestures();
-    }
   }
   unload() {
     var _a;
@@ -250,30 +247,7 @@ var FloatingManager = class {
       btn.addEventListener("touchstart", handler, { passive: false });
     });
   }
-  setupMobileGestures() {
-    document.addEventListener("touchstart", (e) => {
-      this.longPressTimer = setTimeout(() => {
-        const view = this.app.workspace.getActiveViewOfType(import_obsidian.MarkdownView);
-        const sel = window.getSelection();
-        if (view && view.getMode() === "preview" && (sel == null ? void 0 : sel.toString().trim())) {
-          this.plugin.highlightSelection(view);
-          this.hide();
-        }
-      }, 600);
-    }, { passive: true });
-    document.addEventListener("touchmove", () => {
-      if (this.longPressTimer) {
-        clearTimeout(this.longPressTimer);
-        this.longPressTimer = null;
-      }
-    }, { passive: true });
-    document.addEventListener("touchend", () => {
-      if (this.longPressTimer) {
-        clearTimeout(this.longPressTimer);
-        this.longPressTimer = null;
-      }
-    }, { passive: true });
-  }
+
   handleSelection() {
     var _a;
     const view = this.app.workspace.getActiveViewOfType(import_obsidian.MarkdownView);
@@ -1035,6 +1009,27 @@ var ReadingHighlighterPlugin = class extends import_obsidian5.Plugin {
     this.registerCommands();
     this.registerDomEvent(document, "selectionchange", () => {
       this.floatingManager.handleSelection();
+    });
+    this.registerDomEvent(document, "click", (evt) => {
+      const target = evt.target;
+      if (!(target instanceof HTMLElement))
+        return;
+      const markEl = target.closest("mark");
+      if (!markEl)
+        return;
+      const view = this.getActiveReadingView();
+      if (!view)
+        return;
+      const sel = window.getSelection();
+      if (sel && !sel.isCollapsed)
+        return;
+      const previewEl = view.containerEl.querySelector(".markdown-reading-view") || view.containerEl.querySelector(".markdown-preview-view");
+      if (!previewEl || !previewEl.contains(markEl))
+        return;
+      const range = document.createRange();
+      range.selectNodeContents(markEl);
+      sel.removeAllRanges();
+      sel.addRange(range);
     });
     this.registerEvent(
       this.app.workspace.on("active-leaf-change", () => {


### PR DESCRIPTION
… highlight to select it

## 1. Fix: Auto-highlight on Android (erratic behavior)

**Problem:** On Android, selecting a word in Reading View would immediately highlight it without showing the floating toolbar, making it impossible to choose other actions (tag, quote, annotate, etc.). The toolbar would flash briefly and disappear. On Windows, Mac, and iOS, the toolbar appeared correctly.

**Root cause:** The `setupMobileGestures()` method in `FloatingManager` registered a `touchstart` listener that started a 600ms timer. When the timer fired, it called `highlightSelection()` directly and then `hide()` on the toolbar. On iOS, the OS emits a `touchmove` during native word selection which cancels the timer. On Android, word selection completes in ~300-500ms without emitting `touchmove`, so the timer always fires and auto-highlights before the user can interact with the toolbar.

**Solution:** Removed the `setupMobileGestures()` method entirely and its call in `load()`. The normal `selectionchange` event handler already provides the correct flow on all platforms: user selects text → toolbar appears → user picks an action.

**Changes in `main.js`:**

- **Removed** the call to `setupMobileGestures()` inside the `load()` method (was inside `if (Platform.isMobile)` block).
- **Removed** the entire `setupMobileGestures()` method definition (~24 lines) that registered `touchstart`, `touchmove`, and `touchend` listeners with the 600ms auto-highlight timer.

## 2. Feature: Tap on highlight to select it

**Problem:** To remove a highlight, the user had to manually select the exact same portion of text and then press the remove button. This was unintuitive and error-prone, especially on mobile.

**Solution:** Added a `click` event listener that detects when the user clicks/taps on a `<mark>` element in Reading View. When detected, it programmatically selects the full text content of that `<mark>`, which triggers the existing `selectionchange` handler and shows the floating toolbar with all buttons (including remove). This works identically on all platforms.

The handler only fires on simple clicks (checks `sel.isCollapsed`), so it does not interfere with manual drag-selection or long-press text selection.

**Changes in `main.js`:**

- **Added** a new `registerDomEvent(document, "click", ...)` handler in the `onload()` method, right after the existing `selectionchange` handler. The handler:
  1. Checks if the click target is inside a `<mark>` element.
  2. Verifies we're in Reading View.
  3. Checks the selection is collapsed (simple click, not a drag).
  4. Confirms the `<mark>` is inside the preview container.
  5. Creates a `Range` selecting the full `<mark>` contents and applies it.